### PR TITLE
fix: prevent theme flicker during archive era transitions

### DIFF
--- a/src/scripts/archive-observer.ts
+++ b/src/scripts/archive-observer.ts
@@ -52,21 +52,40 @@ export function initArchiveObserver() {
 
 	const controller = shelf ? createShelfController(shelf, 'center') : null;
 
-	// IntersectionObserver: reveal capsules and track active
-	const observer = new IntersectionObserver(
-		(entries) => {
-			let bestEntry: IntersectionObserverEntry | null = null;
-			let bestRatio = 0;
+	// IntersectionObserver: reveal capsules and track active.
+	// On each callback, scan ALL capsules' viewport positions to find the
+	// most prominent one.  This avoids the classic IO pitfall where only
+	// threshold-crossing entries are delivered, causing brief palette flips
+	// when the outgoing section fires alone with a stale ratio.
+	const capsuleArray = Array.from(capsules);
+	const activationLine = 0.4; // fraction of viewport height
 
-			for (const entry of entries) {
-				if (entry.intersectionRatio > bestRatio) {
-					bestRatio = entry.intersectionRatio;
-					bestEntry = entry;
-				}
+	function findActiveCapsule(): { el: HTMLElement; idx: number } | null {
+		const target = window.innerHeight * activationLine;
+		let best: HTMLElement | null = null;
+		let bestIdx = -1;
+		let bestDist = Number.POSITIVE_INFINITY;
+
+		for (let i = 0; i < capsuleArray.length; i++) {
+			const rect = capsuleArray[i].getBoundingClientRect();
+			// Capsule must overlap the viewport
+			if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
+			// Distance from capsule's vertical center to the activation line
+			const center = (rect.top + rect.bottom) / 2;
+			const dist = Math.abs(center - target);
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = capsuleArray[i];
+				bestIdx = i;
 			}
+		}
+		return best ? { el: best, idx: bestIdx } : null;
+	}
 
-			const capsuleArray = Array.from(capsules);
-			const activeIndex = bestEntry ? capsuleArray.indexOf(bestEntry.target as HTMLElement) : -1;
+	const observer = new IntersectionObserver(
+		() => {
+			const active = findActiveCapsule();
+			const activeIndex = active ? active.idx : -1;
 
 			capsuleArray.forEach((capsule, i) => {
 				const rect = capsule.getBoundingClientRect();
@@ -82,11 +101,10 @@ export function initArchiveObserver() {
 				}
 			});
 
-			if (bestEntry && bestRatio > 0.1) {
-				const id = (bestEntry.target as HTMLElement).dataset.capsuleId;
-				const idx = capsuleArray.indexOf(bestEntry.target as HTMLElement);
+			if (active) {
+				const id = active.el.dataset.capsuleId;
 				if (id) applyPalette(id);
-				if (idx >= 0) controller?.update(idx);
+				controller?.update(active.idx);
 			}
 		},
 		{


### PR DESCRIPTION
## Summary
- Fix a bug where the archive page theme would briefly toggle back to the previous era's palette during scroll transitions
- Root cause: `IntersectionObserver` only delivers entries for elements crossing threshold boundaries, so the outgoing capsule could fire alone and temporarily "win" the palette selection
- Fix: scan all capsules' actual viewport positions (`getBoundingClientRect`) on each callback to deterministically pick the capsule closest to the 40% viewport activation line

## Test plan
- [x] Open `/archive` and scroll down continuously through era transitions
- [x] Verify the theme swaps cleanly without flickering back to the previous palette
- [x] Verify scrolling back up also transitions smoothly
- [ ] Check no-JS fallback still works (capsules visible without JS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)