### PR TITLE
[codex] fix archive era end dates

### DIFF
--- a/src/data/archive.ts
+++ b/src/data/archive.ts
@@ -11,6 +11,7 @@ export const eras: ArchiveEra[] = [
 		id: 'era-0',
 		eraNumber: 0,
 		date: new Date('2018-10-05'),
+		endDate: new Date('2019-02-06'),
 		title: 'The FTP Era',
 		description:
 			"Where it all started. Hand-written HTML and CSS, uploaded to Bluehost via FTP. Zilla Slab font, red links, and a lamp banner header. Ed's Bootcamp Blog.",
@@ -34,7 +35,7 @@ export const eras: ArchiveEra[] = [
 		id: 'era-1',
 		eraNumber: 1,
 		date: new Date('2019-02-06'),
-		endDate: new Date('2019-08-01'),
+		endDate: new Date('2019-11-01'),
 		title: 'React + Rails',
 		description:
 			'Full-stack rebuild with a React frontend and Rails API. Had its own login system and a live-preview article editor. Deployed across Netlify and Heroku.',
@@ -100,7 +101,7 @@ export const eras: ArchiveEra[] = [
 		id: 'era-3',
 		eraNumber: 3,
 		date: new Date('2021-06-24'),
-		endDate: new Date('2023-12-31'),
+		endDate: new Date('2024-01-01'),
 		title: 'Dark Mode Gatsby',
 		description:
 			'Complete rewrite to Gatsby v3 with a dark theme. CSS Modules, VSCode-based syntax highlighting, Times serif font. Cut dependencies from 28 to 16.',

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -48,4 +48,15 @@ describe('archive eras', () => {
 			expect(eras[i].eraNumber).toBe(i);
 		}
 	});
+
+	it('each completed era ends when the next era begins', () => {
+		for (let i = 0; i < eras.length - 1; i++) {
+			expect(
+				eras[i].endDate?.getTime(),
+				`${eras[i].id} should end when ${eras[i + 1].id} begins`,
+			).toBe(eras[i + 1].date.getTime());
+		}
+
+		expect(eras[eras.length - 1].endDate).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary
- correct the archive era boundary dates so each completed era ends when the next era begins
- fix Era 0 showing `2018–present` by giving it the start date of Era 1
- add a regression test that enforces the next-era boundary rule for all completed eras

## Root cause
The archive timeline label uses each era's `endDate` when present and falls back to `present` otherwise. Era 0 was missing an `endDate`, and a couple of other eras had hand-maintained end dates that no longer matched the next era's start date.

## Impact
The archive page now shows accurate year ranges for all completed eras, and the test suite will catch future drift in the era metadata.

## Validation
- `npm test`
